### PR TITLE
Return on writerow

### DIFF
--- a/src/backports/csv.py
+++ b/src/backports/csv.py
@@ -201,7 +201,7 @@ class writer(object):
         row = [self.strategy.prepare(field, only=only) for field in row]
 
         line = self.dialect.delimiter.join(row) + self.dialect.lineterminator
-        self.fileobj.write(line)
+        return self.fileobj.write(line)
 
     def writerows(self, rows):
         for row in rows:

--- a/tests.py
+++ b/tests.py
@@ -1054,6 +1054,12 @@ class TestRegression(TestCase):
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), expected)
 
+    def test_writerow_return(self):
+        """writerow should return the return value from calling write."""
+        with TemporaryFile('w+', newline='', encoding='utf-8') as fileobj:
+            writer = csv.writer(fileobj)
+            self.assertEqual(writer.writerow([10, 10.0, 'Piña Colada']), 21)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This matches the functionality in the python2 and python3 implementations of the CSV module. A use case is using a custom file like object that expects a value back on write. An example of such is in the Django docs which uses a generator to stream a CSV response: https://docs.djangoproject.com/en/1.11/howto/outputting-csv/#streaming-large-csv-files