### PR TITLE
Pass reader error messages along

### DIFF
--- a/src/backports/csv.py
+++ b/src/backports/csv.py
@@ -228,8 +228,8 @@ class reader(object):
 
         try:
             self.dialect = Dialect.combine(dialect, fmtparams)
-        except Error:
-            raise TypeError('Invalid dialect parameters')
+        except Error as e:
+            raise TypeError(*e.args)
 
         self.fields = None
         self.field = None


### PR DESCRIPTION
This fixes problems like the one mentioned in issue #27 where using the reader in Python 2.x with it's default `str` type would throw an error, but the error message was overridden. There was a similar change made for issue #5.

I don't believe a new test is required for this since the [`TestDialectValidity.test_delimiter`](https://github.com/ryanhiebert/backports.csv/blob/1.0.5/tests.py#L853-L856) test covers the source exception and this is more about the messaging bubbling up. It would be possible if needed to check the message higher up the chain though.